### PR TITLE
Use generics for BaseEntity id type

### DIFF
--- a/src/main/java/com/lprevidente/permissio/entity/BaseEntity.java
+++ b/src/main/java/com/lprevidente/permissio/entity/BaseEntity.java
@@ -1,5 +1,5 @@
 package com.lprevidente.permissio.entity;
 
-public interface BaseEntity {
-  long getId();
+public interface BaseEntity<ID> {
+  ID getId();
 }

--- a/src/main/java/com/lprevidente/permissio/entity/Group.java
+++ b/src/main/java/com/lprevidente/permissio/entity/Group.java
@@ -2,7 +2,7 @@ package com.lprevidente.permissio.entity;
 
 import java.util.Collection;
 
-public interface Group<T extends BaseEntity<ID>, ID> extends BaseEntity<ID> {
+public interface Group<T extends BaseEntity<ID>, ID> {
 
   Collection<T> getMembers();
 }

--- a/src/main/java/com/lprevidente/permissio/entity/Group.java
+++ b/src/main/java/com/lprevidente/permissio/entity/Group.java
@@ -2,7 +2,7 @@ package com.lprevidente.permissio.entity;
 
 import java.util.Collection;
 
-public interface Group extends BaseEntity {
+public interface Group<T extends BaseEntity<ID>, ID> extends BaseEntity<ID> {
 
-  <T extends BaseEntity> Collection<T> getMembers();
+  Collection<T> getMembers();
 }

--- a/src/main/java/com/lprevidente/permissio/repository/AcRepository.java
+++ b/src/main/java/com/lprevidente/permissio/repository/AcRepository.java
@@ -1,24 +1,21 @@
 package com.lprevidente.permissio.repository;
 
 import com.lprevidente.permissio.entity.BaseEntity;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.support.JpaRepositoryImplementation;
 import org.springframework.data.repository.NoRepositoryBean;
-import org.springframework.data.repository.Repository;
 
 @NoRepositoryBean
-public interface AcRepository<T extends BaseEntity> extends JpaRepositoryImplementation<T, Long> {
+public interface AcRepository<T extends BaseEntity<ID>, ID>
+    extends JpaRepositoryImplementation<T, ID> {
 
   EntityManager getEntityManager();
 
@@ -26,7 +23,7 @@ public interface AcRepository<T extends BaseEntity> extends JpaRepositoryImpleme
 
   Predicate getPredicateRelated(Specification specification, Path<T> path, CriteriaBuilder cb);
 
-  Optional<T> findById(long id, Specification specification);
+  Optional<T> findById(ID id, Specification specification);
 
   List<T> findAll(Specification specification);
 
@@ -34,11 +31,12 @@ public interface AcRepository<T extends BaseEntity> extends JpaRepositoryImpleme
 
   List<T> findAll(Specification specification, Sort sort, String entityGraph);
 
-  List<T> findAllById(Collection<Long> ids, Specification specification);
+  List<T> findAllById(Collection<ID> ids, Specification specification);
 
-  List<T> findAllById(Collection<Long> ids, Specification specification, Sort sort);
+  List<T> findAllById(Collection<ID> ids, Specification specification, Sort sort);
 
-  List<T> findAllById(Collection<Long> ids, Specification specification, Sort sort, String entityGraph);
+  List<T> findAllById(
+      Collection<ID> ids, Specification specification, Sort sort, String entityGraph);
 
   List<T> findAllRelated(Specification specification);
 
@@ -46,7 +44,7 @@ public interface AcRepository<T extends BaseEntity> extends JpaRepositoryImpleme
 
   List<T> findAllRelated(Specification specification, Sort sort, String entityGraph);
 
-  boolean existsById(Long id, Specification specification);
+  boolean existsById(ID id, Specification specification);
 
-  Map<Long, Boolean> existsById(Collection<Long> ids, Specification specification);
+  Map<ID, Boolean> existsById(Collection<ID> ids, Specification specification);
 }

--- a/src/main/java/com/lprevidente/permissio/repository/AcRepositoryFactory.java
+++ b/src/main/java/com/lprevidente/permissio/repository/AcRepositoryFactory.java
@@ -2,7 +2,6 @@ package com.lprevidente.permissio.repository;
 
 import com.lprevidente.permissio.entity.BaseEntity;
 import jakarta.persistence.EntityManager;
-import java.io.Serializable;
 import org.springframework.data.jpa.repository.support.JpaEntityInformation;
 import org.springframework.data.jpa.repository.support.JpaRepositoryFactory;
 import org.springframework.data.jpa.repository.support.JpaRepositoryImplementation;
@@ -10,7 +9,7 @@ import org.springframework.data.repository.core.RepositoryInformation;
 import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.lang.NonNull;
 
-public class AcRepositoryFactory extends JpaRepositoryFactory {
+public class AcRepositoryFactory<ID> extends JpaRepositoryFactory {
 
   public AcRepositoryFactory(EntityManager entityManager) {
     super(entityManager);
@@ -18,10 +17,10 @@ public class AcRepositoryFactory extends JpaRepositoryFactory {
 
   @NonNull
   @Override
-  protected JpaRepositoryImplementation<BaseEntity, Long> getTargetRepository(
+  protected JpaRepositoryImplementation<BaseEntity<ID>, ID> getTargetRepository(
       RepositoryInformation information, EntityManager entityManager) {
-    JpaEntityInformation<?, Serializable> ei = getEntityInformation(information.getDomainType());
-    return new AcRepositoryImpl<>(entityManager, ei, information.getDomainType());
+    JpaEntityInformation ei = getEntityInformation(information.getDomainType());
+    return new AcRepositoryImpl<>(entityManager, ei);
   }
 
   @NonNull

--- a/src/main/java/com/lprevidente/permissio/repository/AcRepositoryFactoryBean.java
+++ b/src/main/java/com/lprevidente/permissio/repository/AcRepositoryFactoryBean.java
@@ -11,8 +11,8 @@ import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
-public class AcRepositoryFactoryBean<T extends AcRepository<S>, S extends BaseEntity>
-    extends TransactionalRepositoryFactoryBeanSupport<T, S, Long> {
+public class AcRepositoryFactoryBean<T extends AcRepository<S, ID>, S extends BaseEntity<ID>, ID>
+    extends TransactionalRepositoryFactoryBeanSupport<T, S, ID> {
 
   @Nullable private EntityManager entityManager;
 
@@ -41,7 +41,7 @@ public class AcRepositoryFactoryBean<T extends AcRepository<S>, S extends BaseEn
   @NonNull
   protected RepositoryFactorySupport doCreateRepositoryFactory() {
     Assert.state(entityManager != null, "EntityManager must not be null");
-    return new AcRepositoryFactory(entityManager);
+    return new AcRepositoryFactory<ID>(entityManager);
   }
 
   @Override

--- a/src/main/java/com/lprevidente/permissio/restrictions/AccessByCreatorRestriction.java
+++ b/src/main/java/com/lprevidente/permissio/restrictions/AccessByCreatorRestriction.java
@@ -29,7 +29,7 @@ public class AccessByCreatorRestriction extends Traversable implements Restricti
       CriteriaBuilder cb,
       Map<String, Join<?, ?>> joinMap) {
 
-    final var fieldPath = path.get(fields.get(0));
+    final var fieldPath = path.get(fields.getFirst());
     final var returnType = fieldPath.getJavaType();
 
     if (fields.size() == 1 && returnType == Long.class)

--- a/src/main/java/com/lprevidente/permissio/restrictions/AccessByIdRestriction.java
+++ b/src/main/java/com/lprevidente/permissio/restrictions/AccessByIdRestriction.java
@@ -9,27 +9,27 @@ import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
 import java.util.Map;
 
-public class AccessByIdRestriction implements Restriction<BaseEntity> {
-  private final long id;
+public class AccessByIdRestriction<ID> implements Restriction<BaseEntity<ID>> {
+  private final ID id;
 
   @JsonCreator
-  public AccessByIdRestriction(@JsonProperty("id") long id) {
+  public AccessByIdRestriction(@JsonProperty("id") ID id) {
     this.id = id;
   }
 
-  public long getId() {
+  public ID getId() {
     return id;
   }
 
   @Override
-  public boolean isSatisfiedBy(Requester requester, BaseEntity baseEntity) {
+  public boolean isSatisfiedBy(Requester requester, BaseEntity<ID> baseEntity) {
     return baseEntity.getId() == id;
   }
 
   @Override
   public Predicate toPredicate(
       Requester requester,
-      Path<? extends BaseEntity> path,
+      Path<? extends BaseEntity<ID>> path,
       CriteriaBuilder cb,
       Map<String, Join<?, ?>> join) {
 

--- a/src/main/java/com/lprevidente/permissio/restrictions/AccessByMemberRestriction.java
+++ b/src/main/java/com/lprevidente/permissio/restrictions/AccessByMemberRestriction.java
@@ -10,7 +10,8 @@ import jakarta.persistence.criteria.Predicate;
 import java.util.Map;
 import org.springframework.util.Assert;
 
-public class AccessByMemberRestriction extends Traversable implements Restriction<Group> {
+public class AccessByMemberRestriction<T extends BaseEntity<ID>, ID> extends Traversable
+    implements Restriction<Group<T, ID>> {
 
   public AccessByMemberRestriction() {
     super("members");
@@ -22,14 +23,14 @@ public class AccessByMemberRestriction extends Traversable implements Restrictio
   }
 
   @Override
-  public boolean isSatisfiedBy(Requester requester, Group obj) {
+  public boolean isSatisfiedBy(Requester requester, Group<T, ID> obj) {
     return obj.getMembers().stream().map(BaseEntity::getId).anyMatch(id -> id == requester.getId());
   }
 
   @Override
   public Predicate toPredicate(
       Requester requester,
-      Path<? extends Group> path,
+      Path<? extends Group<T, ID>> path,
       CriteriaBuilder cb,
       Map<String, Join<?, ?>> join) {
     final var lastPath = getLastPath(path, join);

--- a/src/main/java/com/lprevidente/permissio/restrictions/Requester.java
+++ b/src/main/java/com/lprevidente/permissio/restrictions/Requester.java
@@ -5,11 +5,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class Requester {
-  protected long id;
+  protected Long id;
   protected Map<String, Restriction> permissions;
 
   public Requester(
-      @JsonProperty("id") long id,
+      @JsonProperty("id") Long id,
       @JsonProperty("permissions") Map<String, Restriction> permissions) {
     this.id = id;
     this.permissions = permissions;
@@ -19,7 +19,7 @@ public class Requester {
     return new Builder();
   }
 
-  public long getId() {
+  public Long getId() {
     return id;
   }
 

--- a/src/test/java/com/lprevidente/permissio/repository/Office.java
+++ b/src/test/java/com/lprevidente/permissio/repository/Office.java
@@ -11,8 +11,8 @@ import org.springframework.lang.Nullable;
 
 @Entity
 @Table(name = "offices")
-public class Office implements BaseEntity, Group, Creatable, HandlerEntity {
-  @Id private long id;
+public class Office implements BaseEntity<Long>, Group<User, Long>, Creatable, HandlerEntity {
+  @Id private Long id;
 
   private String name;
 
@@ -33,7 +33,7 @@ public class Office implements BaseEntity, Group, Creatable, HandlerEntity {
   private User handler;
 
   @Override
-  public long getId() {
+  public Long getId() {
     return id;
   }
 

--- a/src/test/java/com/lprevidente/permissio/repository/OfficeRepository.java
+++ b/src/test/java/com/lprevidente/permissio/repository/OfficeRepository.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 
 @Repository
 @Transactional
-public interface OfficeRepository extends AcRepository<Office> {
+public interface OfficeRepository extends AcRepository<Office, Long> {
 
   @Query("select o from Office o where o.name = :name")
   Optional<Office> findByName(String name);

--- a/src/test/java/com/lprevidente/permissio/repository/PredicateTest.java
+++ b/src/test/java/com/lprevidente/permissio/repository/PredicateTest.java
@@ -15,7 +15,7 @@ import org.springframework.test.context.jdbc.Sql;
 @EnableAcRepositories("com.lprevidente.permissio.repository")
 @Sql(scripts = "classpath:users.sql")
 @Sql(
-    statements = "DELETE FROM users; DELETE FROM teams; DELETE FROM offices",
+    statements = "DELETE FROM users; DELETE FROM teams; DELETE FROM offices;",
     executionPhase = AFTER_TEST_METHOD)
 class PredicateTest {
 
@@ -30,7 +30,7 @@ class PredicateTest {
     void noHasPermission() {
       final var specification =
           Specification.builder()
-              .request(new Requester(1, Map.of()))
+              .request(new Requester(1L, Map.of()))
               .permission("user:read")
               .build();
 
@@ -40,7 +40,8 @@ class PredicateTest {
 
     @Test
     void noPermission() {
-      final var specification = Specification.builder().request(new Requester(1, Map.of())).build();
+      final var specification =
+          Specification.builder().request(new Requester(1L, Map.of())).build();
 
       final var users = userRepository.findAll(specification);
       assertThat(users).isNotEmpty();
@@ -53,7 +54,7 @@ class PredicateTest {
     void byId() {
       final var specification =
           Specification.builder()
-              .request(new Requester(1, Map.of("user:read", new AccessByIdRestriction(1))))
+              .request(new Requester(1L, Map.of("user:read", new AccessByIdRestriction<>(1))))
               .permission("user:read")
               .build();
 
@@ -70,7 +71,7 @@ class PredicateTest {
       final var specification =
           Specification.builder()
               .request(
-                  new Requester(1, Map.of("user:read", new AccessByCreatorRestriction("creator"))))
+                  new Requester(1L, Map.of("user:read", new AccessByCreatorRestriction("creator"))))
               .permission("user:read")
               .build();
 
@@ -83,7 +84,7 @@ class PredicateTest {
 
       final var specification =
           Specification.builder()
-              .request(new Requester(1, Map.of("office:read", new AccessByCreatorRestriction())))
+              .request(new Requester(1L, Map.of("office:read", new AccessByCreatorRestriction())))
               .permission("office:read")
               .build();
 
@@ -97,11 +98,11 @@ class PredicateTest {
 
     @Test
     void byMemberRestrictionOneToMany() {
-      final var restriction = new AccessByMemberRestriction();
+      final var restriction = new AccessByMemberRestriction<>();
 
       final var specification =
           Specification.builder()
-              .request(new Requester(1, Map.of("office:read", restriction)))
+              .request(new Requester(1L, Map.of("office:read", restriction)))
               .permission("office:read")
               .build();
 
@@ -111,11 +112,11 @@ class PredicateTest {
 
     @Test
     void byMemberRestrictionManyToMany() {
-      final var restriction = new AccessByMemberRestriction("attendees");
+      final var restriction = new AccessByMemberRestriction<>("attendees");
 
       final var specification =
           Specification.builder()
-              .request(new Requester(1, Map.of("office:read", restriction)))
+              .request(new Requester(1L, Map.of("office:read", restriction)))
               .permission("office:read")
               .build();
 
@@ -126,11 +127,11 @@ class PredicateTest {
     @Test
     void byMemberRestrictionCrossTable() {
 
-      final var restriction = new AccessByMemberRestriction("members:member");
+      final var restriction = new AccessByMemberRestriction<>("members:member");
 
       final var specification =
           Specification.builder()
-              .request(new Requester(1, Map.of("team:read", restriction)))
+              .request(new Requester(1L, Map.of("team:read", restriction)))
               .permission("team:read")
               .build();
 
@@ -148,7 +149,7 @@ class PredicateTest {
 
       final var specification =
           Specification.builder()
-              .request(new Requester(1, Map.of("user:read", restriction)))
+              .request(new Requester(1L, Map.of("user:read", restriction)))
               .permission("user:read")
               .build();
 
@@ -163,7 +164,7 @@ class PredicateTest {
 
       final var specification =
           Specification.builder()
-              .request(new Requester(1, Map.of("user:read", restriction)))
+              .request(new Requester(1L, Map.of("user:read", restriction)))
               .permission("user:read")
               .build();
 
@@ -177,7 +178,7 @@ class PredicateTest {
 
       final var specification =
           Specification.builder()
-              .request(new Requester(1, Map.of("user:read", restriction)))
+              .request(new Requester(1L, Map.of("user:read", restriction)))
               .permission("user:read")
               .build();
 
@@ -191,7 +192,7 @@ class PredicateTest {
 
       final var specification =
           Specification.builder()
-              .request(new Requester(1, Map.of("user:read", restriction)))
+              .request(new Requester(1L, Map.of("user:read", restriction)))
               .permission("user:read")
               .build();
 
@@ -206,11 +207,11 @@ class PredicateTest {
     void byAndRestriction() {
       final var restriction =
           new AndRestriction(
-              new AccessByIdRestriction(2L), new AccessByCreatorRestriction("creator:id"));
+              new AccessByIdRestriction<>(2L), new AccessByCreatorRestriction("creator:id"));
 
       final var specification =
           Specification.builder()
-              .request(new Requester(1, Map.of("user:read", restriction)))
+              .request(new Requester(1L, Map.of("user:read", restriction)))
               .permission("user:read")
               .build();
 
@@ -224,7 +225,7 @@ class PredicateTest {
 
       final var specification =
           Specification.builder()
-              .request(new Requester(1, Map.of("user:read", restriction)))
+              .request(new Requester(1L, Map.of("user:read", restriction)))
               .permission("user:read")
               .build();
 
@@ -240,11 +241,11 @@ class PredicateTest {
     void byOrRestriction() {
       final var restriction =
           new OrRestriction(
-              new AccessByIdRestriction(1L), new AccessByCreatorRestriction("creator:id"));
+              new AccessByIdRestriction<>(1L), new AccessByCreatorRestriction("creator:id"));
 
       final var specification =
           Specification.builder()
-              .request(new Requester(1, Map.of("user:read", restriction)))
+              .request(new Requester(1L, Map.of("user:read", restriction)))
               .permission("user:read")
               .build();
 
@@ -258,7 +259,7 @@ class PredicateTest {
 
       final var specification =
           Specification.builder()
-              .request(new Requester(1, Map.of("user:read", restriction)))
+              .request(new Requester(1L, Map.of("user:read", restriction)))
               .permission("user:read")
               .build();
 
@@ -277,7 +278,7 @@ class PredicateTest {
 
       final var specification =
           Specification.builder()
-              .request(new Requester(1, Map.of("user:read", restriction)))
+              .request(new Requester(1L, Map.of("user:read", restriction)))
               .permission("user:read")
               .build();
 
@@ -292,11 +293,11 @@ class PredicateTest {
     void byRelatedRestrictionOneToMany() {
 
       final var restriction =
-          new AccessByRelatedEntityRestriction("office", new AccessByIdRestriction(1L));
+          new AccessByRelatedEntityRestriction("office", new AccessByIdRestriction<>(1L));
 
       final var specification =
           Specification.builder()
-              .request(new Requester(1, Map.of("user:read", restriction)))
+              .request(new Requester(1L, Map.of("user:read", restriction)))
               .permission("user:read")
               .build();
 
@@ -308,11 +309,11 @@ class PredicateTest {
     void byRelatedRestrictionManyToMany() {
 
       final var restriction =
-          new AccessByRelatedEntityRestriction("teams:team", new AccessByIdRestriction(1L));
+          new AccessByRelatedEntityRestriction("teams:team", new AccessByIdRestriction<>(1L));
 
       final var specification =
           Specification.builder()
-              .request(new Requester(1, Map.of("user:read", restriction)))
+              .request(new Requester(1L, Map.of("user:read", restriction)))
               .permission("user:read")
               .build();
 
@@ -325,11 +326,11 @@ class PredicateTest {
       final var restriction =
           new AccessByRelatedEntityRestriction(
               "teams:team",
-              new OrRestriction(new AccessByIdRestriction(1L), new AccessByIdRestriction(2L)));
+              new OrRestriction(new AccessByIdRestriction<>(1L), new AccessByIdRestriction<>(2L)));
 
       final var specification =
           Specification.builder()
-              .request(new Requester(1, Map.of("user:read", restriction)))
+              .request(new Requester(1L, Map.of("user:read", restriction)))
               .permission("user:read")
               .build();
 
@@ -360,6 +361,4 @@ class PredicateTest {
       assertThat(users).hasSize(1);
     }
   }
-
-
 }

--- a/src/test/java/com/lprevidente/permissio/repository/Product.java
+++ b/src/test/java/com/lprevidente/permissio/repository/Product.java
@@ -1,0 +1,38 @@
+package com.lprevidente.permissio.repository;
+
+import com.lprevidente.permissio.entity.BaseEntity;
+import com.lprevidente.permissio.entity.Creatable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.Objects;
+
+@Entity
+@Table(name = "products")
+public class Product implements BaseEntity<String>, Creatable {
+  @Id private String id;
+
+  private long creatorId;
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public long getCreatorId() {
+    return creatorId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof Product product)) return false;
+    return Objects.equals(id, product.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(id);
+  }
+}

--- a/src/test/java/com/lprevidente/permissio/repository/ProductRepository.java
+++ b/src/test/java/com/lprevidente/permissio/repository/ProductRepository.java
@@ -5,4 +5,4 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 @Transactional
-public interface UserRepository extends AcRepository<User, Long> {}
+public interface ProductRepository extends AcRepository<Product, String> {}

--- a/src/test/java/com/lprevidente/permissio/repository/Team.java
+++ b/src/test/java/com/lprevidente/permissio/repository/Team.java
@@ -10,7 +10,7 @@ import org.hibernate.annotations.Where;
 
 @Entity
 @Table(name = "teams")
-public class Team implements BaseEntity, Group, Handlers {
+public class Team implements BaseEntity<Long>, Group<User, Long>, Handlers {
 
   @Id private long id;
 
@@ -24,7 +24,7 @@ public class Team implements BaseEntity, Group, Handlers {
   private List<TeamMember> handlers;
 
   @Override
-  public long getId() {
+  public Long getId() {
     return id;
   }
 

--- a/src/test/java/com/lprevidente/permissio/repository/TeamRepository.java
+++ b/src/test/java/com/lprevidente/permissio/repository/TeamRepository.java
@@ -5,4 +5,4 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 @Transactional
-public interface TeamRepository extends AcRepository<Team> {}
+public interface TeamRepository extends AcRepository<Team, Long> {}

--- a/src/test/java/com/lprevidente/permissio/repository/User.java
+++ b/src/test/java/com/lprevidente/permissio/repository/User.java
@@ -10,9 +10,9 @@ import org.springframework.lang.Nullable;
 
 @Entity
 @Table(name = "users")
-public class User implements BaseEntity, Creatable, Handlers {
+public class User implements BaseEntity<Long>, Creatable, Handlers {
 
-  @Id private long id;
+  @Id private Long id;
 
   @Nullable
   @ManyToOne(fetch = FetchType.LAZY)
@@ -35,7 +35,7 @@ public class User implements BaseEntity, Creatable, Handlers {
   }
 
   @Override
-  public long getId() {
+  public Long getId() {
     return id;
   }
 

--- a/src/test/java/com/lprevidente/permissio/restrictions/AccessByCreatorRestrictionTest.java
+++ b/src/test/java/com/lprevidente/permissio/restrictions/AccessByCreatorRestrictionTest.java
@@ -12,7 +12,7 @@ class AccessByCreatorRestrictionTest {
     final var restriction = new AccessByCreatorRestriction("creatorId");
 
     final var user = new MockUser();
-    final var requester = new Requester(0, Map.of());
+    final var requester = new Requester(0L, Map.of());
 
     assertThat(restriction.isSatisfiedBy(requester, user)).isTrue();
   }
@@ -22,7 +22,7 @@ class AccessByCreatorRestrictionTest {
     final var restriction = new AccessByCreatorRestriction("creatorId");
 
     final var user = new MockUser();
-    final var requester = new Requester(1, Map.of());
+    final var requester = new Requester(1L, Map.of());
 
     assertThat(restriction.isSatisfiedBy(requester, user)).isFalse();
   }

--- a/src/test/java/com/lprevidente/permissio/restrictions/AccessByHandlerEntityRestrictionTest.java
+++ b/src/test/java/com/lprevidente/permissio/restrictions/AccessByHandlerEntityRestrictionTest.java
@@ -12,7 +12,7 @@ class AccessByHandlerEntityRestrictionTest {
     final var restriction = new AccessByHandlersRestriction("*", "handlers");
 
     final var user = new MockUser();
-    final var requester = new Requester(0, Map.of());
+    final var requester = new Requester(0L, Map.of());
 
     assertThat(restriction.isSatisfiedBy(requester, user)).isTrue();
   }
@@ -22,7 +22,7 @@ class AccessByHandlerEntityRestrictionTest {
     final var restriction = new AccessByHandlersRestriction("OP", "handlers");
 
     final var user = new MockUser();
-    final var requester = new Requester(1, Map.of());
+    final var requester = new Requester(1L, Map.of());
 
     assertThat(restriction.isSatisfiedBy(requester, user)).isFalse();
   }

--- a/src/test/java/com/lprevidente/permissio/restrictions/AccessByIdRestrictionTest.java
+++ b/src/test/java/com/lprevidente/permissio/restrictions/AccessByIdRestrictionTest.java
@@ -9,20 +9,20 @@ class AccessByIdRestrictionTest {
 
   @Test
   void valid() {
-    final var restriction = new AccessByIdRestriction(0);
+    final var restriction = new AccessByIdRestriction<>(0L);
 
     final var user = new MockUser();
-    final var requester = new Requester(1, Map.of());
+    final var requester = new Requester(1L, Map.of());
 
     assertThat(restriction.isSatisfiedBy(requester, user)).isTrue();
   }
 
   @Test
   void notValid() {
-    final var restriction = new AccessByIdRestriction(1L);
+    final var restriction = new AccessByIdRestriction<>(1L);
 
     final var user = new MockUser();
-    final var requester = new Requester(1, Map.of());
+    final var requester = new Requester(1L, Map.of());
 
     assertThat(restriction.isSatisfiedBy(requester, user)).isFalse();
   }

--- a/src/test/java/com/lprevidente/permissio/restrictions/AccessByMemberRestrictionTest.java
+++ b/src/test/java/com/lprevidente/permissio/restrictions/AccessByMemberRestrictionTest.java
@@ -9,20 +9,20 @@ class AccessByMemberRestrictionTest {
 
   @Test
   void valid() {
-    final var restriction = new AccessByMemberRestriction("members");
+    final var restriction = new AccessByMemberRestriction<MockUser, Long>("members");
 
     final var team = new MockTeam();
-    final var requester = new Requester(0, Map.of());
+    final var requester = new Requester(0L, Map.of());
 
     assertThat(restriction.isSatisfiedBy(requester, team)).isTrue();
   }
 
   @Test
   void notValid() {
-    final var restriction = new AccessByMemberRestriction("members");
+    final var restriction = new AccessByMemberRestriction<MockUser, Long>("members");
 
     final var team = new MockTeam();
-    final var requester = new Requester(1, Map.of());
+    final var requester = new Requester(1L, Map.of());
 
     assertThat(restriction.isSatisfiedBy(requester, team)).isFalse();
   }

--- a/src/test/java/com/lprevidente/permissio/restrictions/AccessByRelatedEntityRestrictionTest.java
+++ b/src/test/java/com/lprevidente/permissio/restrictions/AccessByRelatedEntityRestrictionTest.java
@@ -10,10 +10,10 @@ class AccessByRelatedEntityRestrictionTest {
   @Test
   void valid() {
     final var restriction =
-        new AccessByRelatedEntityRestriction("office", new AccessByIdRestriction(0));
+        new AccessByRelatedEntityRestriction("office", new AccessByIdRestriction<>(0L));
 
     final var user = new MockUser();
-    final var requester = new Requester(0, Map.of());
+    final var requester = new Requester(0L, Map.of());
 
     assertThat(restriction.isSatisfiedBy(requester, user)).isTrue();
   }
@@ -21,10 +21,10 @@ class AccessByRelatedEntityRestrictionTest {
   @Test
   void notValid() {
     final var restriction =
-        new AccessByRelatedEntityRestriction("office", new AccessByIdRestriction(1));
+        new AccessByRelatedEntityRestriction("office", new AccessByIdRestriction<>(1L));
 
     final var user = new MockUser();
-    final var requester = new Requester(1, Map.of());
+    final var requester = new Requester(1L, Map.of());
 
     assertThat(restriction.isSatisfiedBy(requester, user)).isFalse();
   }
@@ -32,10 +32,10 @@ class AccessByRelatedEntityRestrictionTest {
   @Test
   void validList() {
     final var restriction =
-        new AccessByRelatedEntityRestriction("teams", new AccessByIdRestriction(0));
+        new AccessByRelatedEntityRestriction("teams", new AccessByIdRestriction<>(0L));
 
     final var user = new MockUser();
-    final var requester = new Requester(0, Map.of());
+    final var requester = new Requester(0L, Map.of());
 
     assertThat(restriction.isSatisfiedBy(requester, user)).isTrue();
   }
@@ -43,10 +43,10 @@ class AccessByRelatedEntityRestrictionTest {
   @Test
   void notValidList() {
     final var restriction =
-        new AccessByRelatedEntityRestriction("teams", new AccessByIdRestriction(1));
+        new AccessByRelatedEntityRestriction("teams", new AccessByIdRestriction<>(1L));
 
     final var user = new MockUser();
-    final var requester = new Requester(1, Map.of());
+    final var requester = new Requester(1L, Map.of());
 
     assertThat(restriction.isSatisfiedBy(requester, user)).isFalse();
   }

--- a/src/test/java/com/lprevidente/permissio/restrictions/AndRestrictionTest.java
+++ b/src/test/java/com/lprevidente/permissio/restrictions/AndRestrictionTest.java
@@ -10,12 +10,12 @@ class AndRestrictionTest {
   @Test
   void valid() {
     final var restriction = new AndRestriction(
-        new AccessByIdRestriction(0L),
+        new AccessByIdRestriction<>(0L),
         new AccessByCreatorRestriction("creatorId")
     );
 
     final var user = new MockUser();
-    final var requester = new Requester(0, Map.of());
+    final var requester = new Requester(0L, Map.of());
 
     assertThat(restriction.isSatisfiedBy(requester, user)).isTrue();
   }
@@ -23,12 +23,12 @@ class AndRestrictionTest {
   @Test
   void notValid() {
     final var restriction = new AndRestriction(
-        new AccessByIdRestriction(1L),
+        new AccessByIdRestriction<>(1L),
         new AccessByCreatorRestriction("creatorId")
     );
 
     final var user = new MockUser();
-    final var requester = new Requester(1, Map.of());
+    final var requester = new Requester(1L, Map.of());
 
     assertThat(restriction.isSatisfiedBy(requester, user)).isFalse();
 

--- a/src/test/java/com/lprevidente/permissio/restrictions/MockOffice.java
+++ b/src/test/java/com/lprevidente/permissio/restrictions/MockOffice.java
@@ -2,10 +2,10 @@ package com.lprevidente.permissio.restrictions;
 
 import com.lprevidente.permissio.entity.BaseEntity;
 
-public class MockOffice implements BaseEntity {
+public class MockOffice implements BaseEntity<Long> {
 
   @Override
-  public long getId() {
-    return 0;
+  public Long getId() {
+    return 0L;
   }
 }

--- a/src/test/java/com/lprevidente/permissio/restrictions/MockTeam.java
+++ b/src/test/java/com/lprevidente/permissio/restrictions/MockTeam.java
@@ -5,15 +5,15 @@ import com.lprevidente.permissio.entity.Group;
 import java.util.Collection;
 import java.util.List;
 
-public class MockTeam implements BaseEntity, Group {
+public class MockTeam implements BaseEntity<Long>, Group<MockUser, Long> {
 
   @Override
-  public long getId() {
-    return 0;
+  public Long getId() {
+    return 0L;
   }
 
   @Override
-  public Collection<BaseEntity> getMembers() {
+  public Collection<MockUser> getMembers() {
     return List.of(new MockUser());
   }
 }

--- a/src/test/java/com/lprevidente/permissio/restrictions/MockUser.java
+++ b/src/test/java/com/lprevidente/permissio/restrictions/MockUser.java
@@ -7,7 +7,7 @@ import com.lprevidente.permissio.entity.HandlerEntity;
 import java.util.Collection;
 import java.util.List;
 
-public class MockUser implements BaseEntity, Creatable, Handlers {
+public class MockUser implements BaseEntity<Long>, Creatable, Handlers {
 
   @Override
   public long getCreatorId() {
@@ -15,8 +15,8 @@ public class MockUser implements BaseEntity, Creatable, Handlers {
   }
 
   @Override
-  public long getId() {
-    return 0;
+  public Long getId() {
+    return 0L;
   }
 
   public MockOffice getOffice() {

--- a/src/test/java/com/lprevidente/permissio/restrictions/OrRestrictionTest.java
+++ b/src/test/java/com/lprevidente/permissio/restrictions/OrRestrictionTest.java
@@ -10,12 +10,12 @@ class OrRestrictionTest {
   @Test
   void valid() {
     final var restriction = new OrRestriction(
-        new AccessByIdRestriction(1L),
+        new AccessByIdRestriction<>(1L),
         new AccessByCreatorRestriction("creatorId")
     );
 
     final var user = new MockUser();
-    final var requester = new Requester(0, Map.of());
+    final var requester = new Requester(0L, Map.of());
 
     assertThat(restriction.isSatisfiedBy(requester, user)).isTrue();
   }
@@ -23,12 +23,12 @@ class OrRestrictionTest {
   @Test
   void notValid() {
     final var restriction = new OrRestriction(
-        new AccessByIdRestriction(1L),
+        new AccessByIdRestriction<>(1L),
         new AccessByCreatorRestriction("creatorId")
     );
 
     final var user = new MockUser();
-    final var requester = new Requester(1, Map.of());
+    final var requester = new Requester(1L, Map.of());
 
     assertThat(restriction.isSatisfiedBy(requester, user)).isFalse();
   }

--- a/src/test/java/com/lprevidente/permissio/serialization/SerializationTest.java
+++ b/src/test/java/com/lprevidente/permissio/serialization/SerializationTest.java
@@ -22,7 +22,7 @@ class SerializationTest {
 
     @Test
     void serialize() throws JsonProcessingException {
-      final var restriction = new AccessByIdRestriction(1);
+      final var restriction = new AccessByIdRestriction<>(1L);
 
       final var res = new ObjectMapper().writeValueAsString(restriction);
       assertThat(res).isEqualTo(json);
@@ -65,7 +65,7 @@ class SerializationTest {
 
     @Test
     void serialize() throws JsonProcessingException {
-      final var restriction = new AccessByMemberRestriction("members");
+      final var restriction = new AccessByMemberRestriction<>("members");
 
       final var res = new ObjectMapper().writeValueAsString(restriction);
       assertThat(res).isEqualTo(json);
@@ -109,7 +109,7 @@ class SerializationTest {
     @Test
     void serialize() throws JsonProcessingException {
       final var restriction =
-          new AndRestriction(new AccessByIdRestriction(1), new AccessByIdRestriction(2));
+          new AndRestriction(new AccessByIdRestriction<>(1L), new AccessByIdRestriction<>(2L));
 
       final var res = new ObjectMapper().writeValueAsString(restriction);
       assertThat(res).isEqualTo(json);

--- a/src/test/java/com/lprevidente/permissio/serialization/SerializationTest.java
+++ b/src/test/java/com/lprevidente/permissio/serialization/SerializationTest.java
@@ -75,7 +75,7 @@ class SerializationTest {
 
     @Test
     void serialize() throws Exception {
-      final var restriction = new AccessByMemberRestriction("members:id");
+      final var restriction = new AccessByMemberRestriction<>("members:id");
 
       final var res = mapper.writeValueAsString(restriction);
       JSONAssert.assertEquals(json, res, true);
@@ -154,7 +154,7 @@ class SerializationTest {
     @Test
     void serialize() throws Exception {
       final var restriction =
-          new OrRestriction(new AccessByIdRestriction(1), new AccessByIdRestriction(2));
+          new OrRestriction(new AccessByIdRestriction<>(1), new AccessByIdRestriction<>(2));
 
       final var res = mapper.writeValueAsString(restriction);
       JSONAssert.assertEquals(json, res, true);
@@ -181,7 +181,7 @@ class SerializationTest {
     @Test
     void serialize() throws Exception {
       final var restriction =
-          new AccessByRelatedEntityRestriction("team", new AccessByIdRestriction(1));
+          new AccessByRelatedEntityRestriction("team", new AccessByIdRestriction<>(1));
 
       final var res = mapper.writeValueAsString(restriction);
       JSONAssert.assertEquals(json, res, true);
@@ -196,7 +196,7 @@ class SerializationTest {
           .hasFieldOrPropertyWithValue("property", "team")
           .extracting(AccessByRelatedEntityRestriction::getRestriction)
           .asInstanceOf(InstanceOfAssertFactories.type(AccessByIdRestriction.class))
-          .hasFieldOrPropertyWithValue("id", 1L);
+          .hasFieldOrPropertyWithValue("id", 1);
     }
   }
 }

--- a/src/test/resources/products.sql
+++ b/src/test/resources/products.sql
@@ -1,0 +1,2 @@
+insert into products (id, creator_id)
+values ('SKU001', 1);


### PR DESCRIPTION
Still needs some work to account for the references to Long.class in AccessByCreator, AccessByHandler. AccessByHandlers and AccessByMember restrictions. Everything else works properly. A very simple test case has been added