### PR TITLE
Begin generic Requester ID refactoring

### DIFF
--- a/src/main/java/com/lprevidente/permissio/entity/Creatable.java
+++ b/src/main/java/com/lprevidente/permissio/entity/Creatable.java
@@ -1,6 +1,6 @@
 package com.lprevidente.permissio.entity;
 
-public interface Creatable {
+public interface Creatable<ID> {
 
-  long getCreatorId();
+  ID getCreatorId();
 }

--- a/src/main/java/com/lprevidente/permissio/entity/Handler.java
+++ b/src/main/java/com/lprevidente/permissio/entity/Handler.java
@@ -1,7 +1,7 @@
 package com.lprevidente.permissio.entity;
 
 
-public interface Handler {
+public interface Handler<ID> {
 
-  <T extends HandlerEntity> T getHandler();
+  <T extends HandlerEntity<ID>> T getHandler();
 }

--- a/src/main/java/com/lprevidente/permissio/entity/HandlerEntity.java
+++ b/src/main/java/com/lprevidente/permissio/entity/HandlerEntity.java
@@ -1,8 +1,8 @@
 package com.lprevidente.permissio.entity;
 
-public interface HandlerEntity {
+public interface HandlerEntity<ID> {
 
-  long getHandlerId();
+  ID getHandlerId();
 
   String getType();
 }

--- a/src/main/java/com/lprevidente/permissio/entity/Handlers.java
+++ b/src/main/java/com/lprevidente/permissio/entity/Handlers.java
@@ -2,7 +2,7 @@ package com.lprevidente.permissio.entity;
 
 import java.util.Collection;
 
-public interface Handlers {
+public interface Handlers<ID> {
 
-  <T extends HandlerEntity> Collection<T> getHandlers();
+  <T extends HandlerEntity<ID>> Collection<T> getHandlers();
 }

--- a/src/main/java/com/lprevidente/permissio/repository/Specification.java
+++ b/src/main/java/com/lprevidente/permissio/repository/Specification.java
@@ -6,10 +6,10 @@ import java.util.List;
 import org.springframework.util.Assert;
 
 public class Specification {
-  private final Requester requester;
+  private final Requester<?> requester;
   private final List<String> permissions;
 
-  private Specification(Requester requester, List<String> permissions) {
+  private Specification(Requester<?> requester, List<String> permissions) {
     Assert.notNull(requester, "The requester cannot be null");
     this.permissions = permissions;
     this.requester = requester;
@@ -23,17 +23,17 @@ public class Specification {
     return permissions;
   }
 
-  public Requester getRequester() {
+  public Requester<?> getRequester() {
     return requester;
   }
 
   public static class SpecificationBuilder {
     private final List<String> permissions = new ArrayList<>();
-    private Requester requester;
+    private Requester<?> requester;
 
     private SpecificationBuilder() {}
 
-    public SpecificationBuilder request(Requester userPrincipal) {
+    public SpecificationBuilder request(Requester<?> userPrincipal) {
       this.requester = userPrincipal;
       return this;
     }

--- a/src/main/java/com/lprevidente/permissio/restrictions/AccessByCreatorRestriction.java
+++ b/src/main/java/com/lprevidente/permissio/restrictions/AccessByCreatorRestriction.java
@@ -7,7 +7,8 @@ import jakarta.persistence.criteria.*;
 import java.util.Map;
 import org.springframework.util.Assert;
 
-public class AccessByCreatorRestriction extends Traversable implements Restriction<Creatable> {
+public class AccessByCreatorRestriction<RequesterID> extends Traversable
+    implements Restriction<Creatable<RequesterID>, Requester<RequesterID>> {
 
   public AccessByCreatorRestriction() {
     super("creatorId");
@@ -20,14 +21,14 @@ public class AccessByCreatorRestriction extends Traversable implements Restricti
   }
 
   @Override
-  public boolean isSatisfiedBy(Requester requester, Creatable obj) {
-    return obj.getCreatorId() == requester.getId();
+  public boolean isSatisfiedBy(Requester<RequesterID> requester, Creatable<RequesterID> obj) {
+    return obj.getCreatorId().equals(requester.getId());
   }
 
   @Override
   public Predicate toPredicate(
-      Requester requester,
-      Path<? extends Creatable> path,
+      Requester<RequesterID> requester,
+      Path<? extends Creatable<RequesterID>> path,
       CriteriaBuilder cb,
       Map<String, Join<?, ?>> joinMap) {
 

--- a/src/main/java/com/lprevidente/permissio/restrictions/AccessByHandlerRestriction.java
+++ b/src/main/java/com/lprevidente/permissio/restrictions/AccessByHandlerRestriction.java
@@ -12,7 +12,8 @@ import java.util.List;
 import java.util.Map;
 import org.springframework.util.Assert;
 
-public class AccessByHandlerRestriction extends Traversable implements Restriction<HandlerEntity> {
+public class AccessByHandlerRestriction<RequesterId> extends Traversable
+    implements Restriction<HandlerEntity<RequesterId>, Requester<RequesterId>> {
   private final String type;
 
   public AccessByHandlerRestriction() {
@@ -37,15 +38,16 @@ public class AccessByHandlerRestriction extends Traversable implements Restricti
   }
 
   @Override
-  public boolean isSatisfiedBy(Requester requester, HandlerEntity entity) {
+  public boolean isSatisfiedBy(
+      Requester<RequesterId> requester, HandlerEntity<RequesterId> entity) {
     return ("*".equals(type) || entity.getType().equals(type))
-        && entity.getHandlerId() == requester.getId();
+        && entity.getHandlerId().equals(requester.getId());
   }
 
   @Override
   public Predicate toPredicate(
-      Requester requester,
-      Path<? extends HandlerEntity> path,
+      Requester<RequesterId> requester,
+      Path<? extends HandlerEntity<RequesterId>> path,
       CriteriaBuilder cb,
       Map<String, Join<?, ?>> join) {
     final var lastPath = getLastPath(path, join);

--- a/src/main/java/com/lprevidente/permissio/restrictions/AccessByHandlersRestriction.java
+++ b/src/main/java/com/lprevidente/permissio/restrictions/AccessByHandlersRestriction.java
@@ -13,7 +13,8 @@ import java.util.List;
 import java.util.Map;
 import org.springframework.util.Assert;
 
-public class AccessByHandlersRestriction extends Traversable implements Restriction<Handlers> {
+public class AccessByHandlersRestriction<RequesterId> extends Traversable
+    implements Restriction<Handlers<RequesterId>, Requester<RequesterId>> {
   private final String type;
 
   public AccessByHandlersRestriction() {
@@ -38,17 +39,17 @@ public class AccessByHandlersRestriction extends Traversable implements Restrict
   }
 
   @Override
-  public boolean isSatisfiedBy(Requester requester, Handlers handlers) {
+  public boolean isSatisfiedBy(Requester<RequesterId> requester, Handlers<RequesterId> handlers) {
     return handlers.getHandlers().stream()
         .filter(handler -> "*".equals(type) || handler.getType().equals(type))
         .map(HandlerEntity::getHandlerId)
-        .anyMatch(id -> id == requester.getId());
+        .anyMatch(id -> id.equals(requester.getId()));
   }
 
   @Override
   public Predicate toPredicate(
-      Requester requester,
-      Path<? extends Handlers> path,
+      Requester<RequesterId> requester,
+      Path<? extends Handlers<RequesterId>> path,
       CriteriaBuilder cb,
       Map<String, Join<?, ?>> join) {
 

--- a/src/main/java/com/lprevidente/permissio/restrictions/AccessByIdRestriction.java
+++ b/src/main/java/com/lprevidente/permissio/restrictions/AccessByIdRestriction.java
@@ -9,7 +9,8 @@ import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
 import java.util.Map;
 
-public class AccessByIdRestriction<ID> implements Restriction<BaseEntity<ID>> {
+public class AccessByIdRestriction<ID, RequesterId>
+    implements Restriction<BaseEntity<ID>, Requester<RequesterId>> {
   private final ID id;
 
   @JsonCreator
@@ -22,13 +23,13 @@ public class AccessByIdRestriction<ID> implements Restriction<BaseEntity<ID>> {
   }
 
   @Override
-  public boolean isSatisfiedBy(Requester requester, BaseEntity<ID> baseEntity) {
-    return baseEntity.getId() == id;
+  public boolean isSatisfiedBy(Requester<RequesterId> requester, BaseEntity<ID> baseEntity) {
+    return baseEntity.getId().equals(id);
   }
 
   @Override
   public Predicate toPredicate(
-      Requester requester,
+      Requester<RequesterId> requester,
       Path<? extends BaseEntity<ID>> path,
       CriteriaBuilder cb,
       Map<String, Join<?, ?>> join) {

--- a/src/main/java/com/lprevidente/permissio/restrictions/AccessByMemberRestriction.java
+++ b/src/main/java/com/lprevidente/permissio/restrictions/AccessByMemberRestriction.java
@@ -11,8 +11,8 @@ import jakarta.persistence.criteria.Predicate;
 import java.util.Map;
 import org.springframework.util.Assert;
 
-public class AccessByMemberRestriction<T extends BaseEntity<ID>, ID> extends Traversable
-    implements Restriction<Group<T, ID>> {
+public class AccessByMemberRestriction<T extends BaseEntity<ID>, ID, RequesterId>
+    extends Traversable implements Restriction<Group<T, ID>, Requester<RequesterId>> {
 
   public AccessByMemberRestriction() {
     super("members");
@@ -25,13 +25,15 @@ public class AccessByMemberRestriction<T extends BaseEntity<ID>, ID> extends Tra
   }
 
   @Override
-  public boolean isSatisfiedBy(Requester requester, Group<T, ID> obj) {
-    return obj.getMembers().stream().map(BaseEntity::getId).anyMatch(id -> id == requester.getId());
+  public boolean isSatisfiedBy(Requester<RequesterId> requester, Group<T, ID> obj) {
+    return obj.getMembers().stream()
+        .map(BaseEntity::getId)
+        .anyMatch(id -> id.equals(requester.getId()));
   }
 
   @Override
   public Predicate toPredicate(
-      Requester requester,
+      Requester<RequesterId> requester,
       Path<? extends Group<T, ID>> path,
       CriteriaBuilder cb,
       Map<String, Join<?, ?>> join) {

--- a/src/main/java/com/lprevidente/permissio/restrictions/AccessByRelatedEntityRestriction.java
+++ b/src/main/java/com/lprevidente/permissio/restrictions/AccessByRelatedEntityRestriction.java
@@ -11,26 +11,27 @@ import java.util.Map;
 import java.util.stream.StreamSupport;
 import org.springframework.util.Assert;
 
-public class AccessByRelatedEntityRestriction extends Traversable implements Restriction<Object> {
+public class AccessByRelatedEntityRestriction<RequesterId> extends Traversable
+    implements Restriction<Object, Requester<RequesterId>> {
 
-  private final Restriction restriction;
+  private final Restriction<?, Requester<RequesterId>> restriction;
 
   @JsonCreator
   public AccessByRelatedEntityRestriction(
       @JsonProperty("property") String property,
-      @JsonProperty("restriction") Restriction restriction) {
+      @JsonProperty("restriction") Restriction<?, Requester<RequesterId>> restriction) {
     super(property);
     Assert.isTrue(fields.size() <= 2, "Property must have at most 2 fields");
     Assert.notNull(restriction, "Properties must not be empty");
     this.restriction = restriction;
   }
 
-  public Restriction getRestriction() {
+  public Restriction<?, Requester<RequesterId>> getRestriction() {
     return restriction;
   }
 
   @Override
-  public boolean isSatisfiedBy(Requester requester, Object baseEntity) {
+  public boolean isSatisfiedBy(Requester<RequesterId> requester, Object baseEntity) {
     final var res = getRelatedEntity(baseEntity, fields.get(0));
 
     if (res instanceof Iterable<?> iterable) {
@@ -61,7 +62,10 @@ public class AccessByRelatedEntityRestriction extends Traversable implements Res
 
   @Override
   public Predicate toPredicate(
-      Requester requester, Path<?> path, CriteriaBuilder cb, Map<String, Join<?, ?>> join) {
+      Requester<RequesterId> requester,
+      Path<?> path,
+      CriteriaBuilder cb,
+      Map<String, Join<?, ?>> join) {
     final var lastPath = joinLastPath(path, join);
     return restriction.toPredicate(requester, lastPath, cb, join);
   }

--- a/src/main/java/com/lprevidente/permissio/restrictions/AndRestriction.java
+++ b/src/main/java/com/lprevidente/permissio/restrictions/AndRestriction.java
@@ -9,28 +9,32 @@ import jakarta.persistence.criteria.Predicate;
 import java.util.Arrays;
 import java.util.Map;
 
-public class AndRestriction implements Restriction<Object> {
+public class AndRestriction<RequesterId> implements Restriction<Object, Requester<RequesterId>> {
 
-  private final Restriction[] restrictions;
+  private final Restriction<?, Requester<RequesterId>>[] restrictions;
 
   @JsonCreator
-  public AndRestriction(@JsonProperty("restrictions") Restriction... restrictions) {
+  public AndRestriction(
+      @JsonProperty("restrictions") Restriction<?, Requester<RequesterId>>... restrictions) {
     this.restrictions = restrictions;
   }
 
-  public Restriction[] getRestrictions() {
+  public Restriction<?, Requester<RequesterId>>[] getRestrictions() {
     return restrictions;
   }
 
   @Override
-  public boolean isSatisfiedBy(Requester requester, Object baseEntity) {
+  public boolean isSatisfiedBy(Requester<RequesterId> requester, Object baseEntity) {
     return Arrays.stream(restrictions)
         .allMatch(restriction -> restriction.isSatisfiedBy(requester, baseEntity));
   }
 
   @Override
   public Predicate toPredicate(
-      Requester requester, Path<?> path, CriteriaBuilder cb, Map<String, Join<?, ?>> join) {
+      Requester<RequesterId> requester,
+      Path<?> path,
+      CriteriaBuilder cb,
+      Map<String, Join<?, ?>> join) {
     return Arrays.stream(restrictions)
         .map(restriction -> restriction.toPredicate(requester, path, cb, join))
         .reduce(cb::and)

--- a/src/main/java/com/lprevidente/permissio/restrictions/ConjunctionRestriction.java
+++ b/src/main/java/com/lprevidente/permissio/restrictions/ConjunctionRestriction.java
@@ -6,16 +6,20 @@ import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
 import java.util.Map;
 
-public class ConjunctionRestriction implements Restriction<Object> {
+public class ConjunctionRestriction<RequesterId>
+    implements Restriction<Object, Requester<RequesterId>> {
 
   @Override
-  public boolean isSatisfiedBy(Requester requester, Object baseEntity) {
+  public boolean isSatisfiedBy(Requester<RequesterId> requester, Object baseEntity) {
     return true;
   }
 
   @Override
   public Predicate toPredicate(
-      Requester requester, Path<?> path, CriteriaBuilder cb, Map<String, Join<?, ?>> join) {
+      Requester<RequesterId> requester,
+      Path<?> path,
+      CriteriaBuilder cb,
+      Map<String, Join<?, ?>> join) {
     return cb.conjunction();
   }
 }

--- a/src/main/java/com/lprevidente/permissio/restrictions/DisjunctionRestriction.java
+++ b/src/main/java/com/lprevidente/permissio/restrictions/DisjunctionRestriction.java
@@ -6,16 +6,20 @@ import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
 import java.util.Map;
 
-public class DisjunctionRestriction implements Restriction<Object> {
+public class DisjunctionRestriction<RequesterId>
+    implements Restriction<Object, Requester<RequesterId>> {
 
   @Override
-  public boolean isSatisfiedBy(Requester requester, Object baseEntity) {
+  public boolean isSatisfiedBy(Requester<RequesterId> requester, Object baseEntity) {
     return false;
   }
 
   @Override
   public Predicate toPredicate(
-      Requester requester, Path<?> path, CriteriaBuilder cb, Map<String, Join<?, ?>> join) {
+      Requester<RequesterId> requester,
+      Path<?> path,
+      CriteriaBuilder cb,
+      Map<String, Join<?, ?>> join) {
     return cb.disjunction();
   }
 }

--- a/src/main/java/com/lprevidente/permissio/restrictions/OrRestriction.java
+++ b/src/main/java/com/lprevidente/permissio/restrictions/OrRestriction.java
@@ -9,27 +9,31 @@ import jakarta.persistence.criteria.Predicate;
 import java.util.Arrays;
 import java.util.Map;
 
-public class OrRestriction implements Restriction<Object> {
-  private final Restriction[] restrictions;
+public class OrRestriction<RequesterId> implements Restriction<Object, Requester<RequesterId>> {
+  private final Restriction<?, Requester<RequesterId>>[] restrictions;
 
   @JsonCreator
-  public OrRestriction(@JsonProperty("restrictions") Restriction... restrictions) {
+  public OrRestriction(
+      @JsonProperty("restrictions") Restriction<?, Requester<RequesterId>>... restrictions) {
     this.restrictions = restrictions;
   }
 
-  public Restriction[] getRestrictions() {
+  public Restriction<?, Requester<RequesterId>>[] getRestrictions() {
     return restrictions;
   }
 
   @Override
-  public boolean isSatisfiedBy(Requester requester, Object baseEntity) {
+  public boolean isSatisfiedBy(Requester<RequesterId> requester, Object baseEntity) {
     return Arrays.stream(restrictions)
         .anyMatch(restriction -> restriction.isSatisfiedBy(requester, baseEntity));
   }
 
   @Override
   public Predicate toPredicate(
-      Requester requester, Path<?> path, CriteriaBuilder cb, Map<String, Join<?, ?>> join) {
+      Requester<RequesterId> requester,
+      Path<?> path,
+      CriteriaBuilder cb,
+      Map<String, Join<?, ?>> join) {
     return Arrays.stream(restrictions)
         .map(restriction -> restriction.toPredicate(requester, path, cb, join))
         .reduce(cb::or)

--- a/src/main/java/com/lprevidente/permissio/restrictions/Requester.java
+++ b/src/main/java/com/lprevidente/permissio/restrictions/Requester.java
@@ -4,22 +4,22 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.HashMap;
 import java.util.Map;
 
-public class Requester {
-  protected Long id;
+public class Requester<ID> {
+  protected ID id;
   protected Map<String, Restriction> permissions;
 
   public Requester(
-      @JsonProperty("id") Long id,
+      @JsonProperty("id") ID id,
       @JsonProperty("permissions") Map<String, Restriction> permissions) {
     this.id = id;
     this.permissions = permissions;
   }
 
-  public static Builder builder() {
-    return new Builder();
+  public static <ID> Builder<ID> builder() {
+    return new Builder<>();
   }
 
-  public Long getId() {
+  public ID getId() {
     return id;
   }
 
@@ -27,24 +27,24 @@ public class Requester {
     return permissions;
   }
 
-  public static class Builder {
+  public static class Builder<ID> {
     protected final Map<String, Restriction> permissions = new HashMap<>();
-    protected long id;
+    protected ID id;
 
     protected Builder() {}
 
-    public Builder id(long id) {
+    public Builder<ID> id(ID id) {
       this.id = id;
       return this;
     }
 
-    public Builder addPermission(String permission, Restriction restriction) {
+    public Builder<ID> addPermission(String permission, Restriction restriction) {
       permissions.put(permission, restriction);
       return this;
     }
 
-    public Requester build() {
-      return new Requester(id, permissions);
+    public Requester<ID> build() {
+      return new Requester<>(id, permissions);
     }
   }
 }

--- a/src/main/java/com/lprevidente/permissio/restrictions/Restriction.java
+++ b/src/main/java/com/lprevidente/permissio/restrictions/Restriction.java
@@ -15,19 +15,18 @@ import java.util.Map;
   @JsonSubTypes.Type(value = AccessByHandlerRestriction.class, name = "accessByHandler"),
   @JsonSubTypes.Type(value = AccessByCreatorRestriction.class, name = "accessByCreator"),
   @JsonSubTypes.Type(value = AccessByMemberRestriction.class, name = "accessByMember"),
-  @JsonSubTypes.Type(value = AccessByRelatedEntityRestriction.class, name = "accessByRelatedEntity"),
+  @JsonSubTypes.Type(
+      value = AccessByRelatedEntityRestriction.class,
+      name = "accessByRelatedEntity"),
   @JsonSubTypes.Type(value = AndRestriction.class, name = "and"),
   @JsonSubTypes.Type(value = OrRestriction.class, name = "or"),
   @JsonSubTypes.Type(value = ConjunctionRestriction.class, name = "*"),
   @JsonSubTypes.Type(value = DisjunctionRestriction.class, name = "-")
 })
-public interface Restriction<T> {
+public interface Restriction<T, R extends Requester<?>> {
 
-  boolean isSatisfiedBy(Requester requester, T obj);
+  boolean isSatisfiedBy(R requester, T obj);
 
   Predicate toPredicate(
-      Requester requester,
-      Path<? extends T> path,
-      CriteriaBuilder cb,
-      Map<String, Join<?, ?>> joinMap);
+      R requester, Path<? extends T> path, CriteriaBuilder cb, Map<String, Join<?, ?>> joinMap);
 }


### PR DESCRIPTION
Start generalizing the way requester id type is defined and used with the Creatable, Member, Handler and Handlers constraint. Still unfinished, doesn't compile. Requires more work to adapt for the Object type in class signatures for AndRestriction, OrRestriction and AccessByRelatedEntityRestriction